### PR TITLE
Update the kernel name

### DIFF
--- a/notebooks/master/Basics.ipynb
+++ b/notebooks/master/Basics.ipynb
@@ -125,9 +125,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "hats-jec",
+   "display_name": "hats-jec-2020",
    "language": "python",
-   "name": "hats-jec"
+   "name": "hats-jec-2020"
   },
   "language_info": {
    "codemirror_mode": {

--- a/notebooks/master/JECNtuple Setup.ipynb
+++ b/notebooks/master/JECNtuple Setup.ipynb
@@ -103,9 +103,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "hats-jec",
+   "display_name": "hats-jec-2020",
    "language": "python",
-   "name": "hats-jec"
+   "name": "hats-jec-2020"
   },
   "language_info": {
    "codemirror_mode": {

--- a/notebooks/master/Jet Energy Corrections - V2.ipynb
+++ b/notebooks/master/Jet Energy Corrections - V2.ipynb
@@ -428,9 +428,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "hats-jec",
+   "display_name": "hats-jec-2020",
    "language": "python",
-   "name": "hats-jec"
+   "name": "hats-jec-2020"
   },
   "language_info": {
    "codemirror_mode": {

--- a/notebooks/master/Jet Energy Corrections.ipynb
+++ b/notebooks/master/Jet Energy Corrections.ipynb
@@ -417,9 +417,9 @@
  "metadata": {
   "celltoolbar": "Slideshow",
   "kernelspec": {
-   "display_name": "hats-jec",
+   "display_name": "hats-jec-2020",
    "language": "python",
-   "name": "hats-jec"
+   "name": "hats-jec-2020"
   },
   "language_info": {
    "codemirror_mode": {

--- a/notebooks/master/Jet Resolution.ipynb
+++ b/notebooks/master/Jet Resolution.ipynb
@@ -377,9 +377,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "hats-jec",
+   "display_name": "hats-jec-2020",
    "language": "python",
-   "name": "hats-jec"
+   "name": "hats-jec-2020"
   },
   "language_info": {
    "codemirror_mode": {

--- a/notebooks/master/Jet Substructure.ipynb
+++ b/notebooks/master/Jet Substructure.ipynb
@@ -341,9 +341,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "hats-jec",
+   "display_name": "hats-jec-2020",
    "language": "python",
-   "name": "hats-jec"
+   "name": "hats-jec-2020"
   },
   "language_info": {
    "codemirror_mode": {

--- a/notebooks/master/Jet Toolbox.ipynb
+++ b/notebooks/master/Jet Toolbox.ipynb
@@ -367,9 +367,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "hats-jec",
+   "display_name": "hats-jec-2020",
    "language": "python",
-   "name": "hats-jec"
+   "name": "hats-jec-2020"
   },
   "language_info": {
    "codemirror_mode": {

--- a/notebooks/master/Jet Types and Algorithms.ipynb
+++ b/notebooks/master/Jet Types and Algorithms.ipynb
@@ -321,9 +321,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "hats-jec",
+   "display_name": "hats-jec-2020",
    "language": "python",
-   "name": "hats-jec"
+   "name": "hats-jec-2020"
   },
   "language_info": {
    "codemirror_mode": {

--- a/notebooks/master/Pileup.ipynb
+++ b/notebooks/master/Pileup.ipynb
@@ -198,9 +198,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "hats-jec",
+   "display_name": "hats-jec-2020",
    "language": "python",
-   "name": "hats-jec"
+   "name": "hats-jec-2020"
   },
   "language_info": {
    "codemirror_mode": {

--- a/notebooks/master/ROC Curves.ipynb
+++ b/notebooks/master/ROC Curves.ipynb
@@ -406,9 +406,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "hats-jec",
+   "display_name": "hats-jec-2020",
    "language": "python",
-   "name": "hats-jec"
+   "name": "hats-jec-2020"
   },
   "language_info": {
    "codemirror_mode": {

--- a/notebooks/master/The JEC Game.ipynb
+++ b/notebooks/master/The JEC Game.ipynb
@@ -351,9 +351,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "hats-jec",
+   "display_name": "hats-jec-2020",
    "language": "python",
-   "name": "hats-jec"
+   "name": "hats-jec-2020"
   },
   "language_info": {
    "codemirror_mode": {

--- a/notebooks/master/W and Top Tagging.ipynb
+++ b/notebooks/master/W and Top Tagging.ipynb
@@ -332,9 +332,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "hats-jec",
+   "display_name": "hats-jec-2020",
    "language": "python",
-   "name": "hats-jec"
+   "name": "hats-jec-2020"
   },
   "language_info": {
    "codemirror_mode": {

--- a/setup-libraries.ipynb
+++ b/setup-libraries.ipynb
@@ -21,7 +21,7 @@
     "#!/bin/bash\n",
     "\n",
     "CMSSW_VER=\"CMSSW_10_6_13\"\n",
-    "KERNEL_NAME=\"hats-jec\"\n",
+    "KERNEL_NAME=\"hats-jec-2020\"\n",
     "\n",
     "set -e\n",
     "# Get the CMSSW libraries (specifically ROOT)\n",
@@ -83,7 +83,7 @@
     "If successful, you should see something similar to the following:\n",
     "\n",
     "```\n",
-    "Loaded CMSSW_10_6_13 into hats-jec!\n",
+    "Loaded CMSSW_10_6_13 into hats-jec-2020!\n",
     "```\n",
     "\n",
     "The new kernel you just made will then show up in the various Jupyter dropdowns, adding it alongside the stock defaults. If you've just run this notebook, you may need to refresh your Jupyter Home page before the new kernel shows up."
@@ -113,7 +113,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.5"
+   "version": "2.7.14+"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR updates the kernel name in the setup and exercise notebooks from `hats-jec` to `hats-jec-2020`.